### PR TITLE
Implement missing glitch and hesitation decay

### DIFF
--- a/clear-lode/fragment-generator.js
+++ b/clear-lode/fragment-generator.js
@@ -75,9 +75,27 @@ export const DIGITAL_MEMORIES = {
  * @returns {string} The corrupted text.
  */
 function applyCorruption(text, level) {
-    // Placeholder: for now, just returns the original text.
-    // Future implementation will apply glitch effects, character replacement, etc.
-    return text;
+    const GLITCH_CHARS = ['▓', '░', '█', '▒', '#', '§', '¶'];
+    return text.split('').map(char => {
+        if (char.trim() === '') return char;
+
+        // random removal
+        if (Math.random() < level * 0.1) {
+            return '';
+        }
+
+        // replace with glitch character
+        if (Math.random() < level * 0.4) {
+            return GLITCH_CHARS[Math.floor(Math.random() * GLITCH_CHARS.length)];
+        }
+
+        // insert html entity corruption
+        if (Math.random() < level * 0.2) {
+            return `&#x${char.charCodeAt(0).toString(16)};`;
+        }
+
+        return char;
+    }).join('');
 }
 
 


### PR DESCRIPTION
## Summary
- create real text corruption effects for memory fragments
- start audio degradation while the user hesitates
- stop the hesitation timer when the user chooses or degradation begins

## Testing
- `npm test` *(fails: Missing script)*
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_68701e39b8408327bcae2491b8ca537b