### PR TITLE
fix(positioning): Use full zone for fragment placement

### DIFF
--- a/clear-lode/fragment-positioning-service.js
+++ b/clear-lode/fragment-positioning-service.js
@@ -157,7 +157,7 @@ export class FragmentPositioningService {
     
     // Fallback to original implementation
     // Get random position within zone bounds
-    let position = zone.getRandomPosition(0.1); // 10% margin within zone
+    let position = zone.getRandomPosition(0); // No margin, use full zone
 
     // Apply distribution-based adjustments if provided
     if (distributionData && distributionData.centerBias) {


### PR DESCRIPTION
Changed the margin in `getRandomPosition` from 0.1 to 0. This allows fragments to be placed anywhere within their designated zone, preventing them from clustering and ensuring a more even distribution across the screen.